### PR TITLE
Slightly lazy fix for Issue #1 - "Sometimes a shortcut is possible but not marked as correct"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ A few fun math games. Hosted on github pages at [https://jasontatton.github.io/m
 
 In the project directory, you can run:
 
+### `npm install`
+
+To install the dependencies. Then...
+
+
 ### `npm run start`
 
-Runs the app in the development mode.\
+To run the app in development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 
 The page will reload when you make changes. You may also see any lint errors in the console.

--- a/src/App.js
+++ b/src/App.js
@@ -67,6 +67,39 @@ function usePositiveNegativeToggle() {
     return {isPositive, Button};
 }
 
+// helper: count all valid paths from start to end
+function countValidPaths(grid, start, end, increment) {
+    const n = grid.length;
+    const visited = Array.from({length: n}, () => Array(n).fill(false));
+    let pathCount = 0;
+
+    function dfs(r, c) {
+        if (r === end.row && c === end.col) {
+            pathCount++;
+            return;
+        }
+        visited[r][c] = true;
+
+        const curr = grid[r][c];
+        const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
+        for (let [dr, dc] of dirs) {
+            const nr = r + dr, nc = c + dc;
+            if (nr>=0 && nr<n && nc>=0 && nc<n && !visited[nr][nc]) {
+                const next = grid[nr][nc];
+                if (Math.abs(next - curr) === Math.abs(increment)) {
+                    dfs(nr, nc);
+                    if (pathCount > 1) return; // early exit if more than 1
+                }
+            }
+        }
+        visited[r][c] = false;
+    }
+
+    dfs(start.row, start.col);
+    return pathCount;
+}
+
+
 function App() {
     const n = 10;
     const [theIncrement, setTheIncrement] = useState(100);
@@ -148,8 +181,10 @@ function App() {
                 break;
             }
 
-        } while (Math.abs(cells[cells.length - 1].row - cells[0].row) +
-        Math.abs(cells[cells.length - 1].col - cells[0].col) < 5);
+        } while ((Math.abs(cells[cells.length - 1].row - cells[0].row) +
+        Math.abs(cells[cells.length - 1].col - cells[0].col) < 5)
+            || countValidPaths(nums, {row: cells[0].row, col: cells[0].col}, {row: cells[cells.length-1].row, col: cells[cells.length-1].col}, increment) > 1
+            );
 
         // Place the path numbers in the grid
         cells.forEach(cell => {


### PR DESCRIPTION
We just see if there is more than one path through the maze, if there is then we regenerate the maze (up to a limit of attempts so as to prevent inf loop).

A better solution is to upfront pick a start and end point, then generate the path through the maze avoiding the 8 cells around the finish (unless its at an edge/corner) til we get to the last point. This will involve implementing backtracking etc.

Anyway this is good enough